### PR TITLE
Fix circuit breaker

### DIFF
--- a/deploy/example-do-deployment.yaml
+++ b/deploy/example-do-deployment.yaml
@@ -120,3 +120,5 @@ spec:
               key: LEDGER_DB_COMMAND_CERTIFICATE
         - name: CHECK_NODES
           value: 'http://MYNODE1.com,http://SOMENODE2.com,http://SOMENODE3.com,http://SOMENODE4.com,http://SOMENODE5.com'
+        - name: ARCHIVE_DB_RECENCY_THRESHOLD
+          value: "5"

--- a/deploy/example-uploadStakingLedgers.sh
+++ b/deploy/example-uploadStakingLedgers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# login information
+USERNAME="BASICAUTHUSER"
+PASSWORD="BASICAUTHPWD"
+# Directory containing the JSON files
+YOUR_LEDGER_DIRECTORY="/home/USERNAME/ledger-archives"
+GARBAGE="Using password from environment variable CODA_PRIVKEY_PASS"
+/usr/local/bin/mina ledger export staking-epoch-ledger | grep -v --regexp="$GARBAGE" > "$YOUR_LEDGER_DIRECTORY/staking-epoch-ledger.json"
+/usr/local/bin/mina ledger export next-epoch-ledger | grep -v --regexp="$GARBAGE" > "$YOUR_LEDGER_DIRECTORY/next-epoch-ledger.json"
+
+for LEDGER in staking-epoch-ledger next-epoch-ledger; do
+    NEW_FILE=$(/usr/local/bin/mina ledger hash --ledger-file "$YOUR_LEDGER_DIRECTORY/$LEDGER.json" | xargs -I % echo "$YOUR_LEDGER_DIRECTORY/%.json")
+    echo will create $NEW_FILE
+    mv "$YOUR_LEDGER_DIRECTORY/$LEDGER.json" "$NEW_FILE"
+    HASH=$(basename "$NEW_FILE" .json)
+
+    echo "Uploading $NEW_FILE for hash $HASH:"
+    # Upload the file and capture the HTTP status code
+    STATUS_CODE=$(curl -k -u "$USERNAME:$PASSWORD" -X POST -H "Content-Type: multipart/form-data" -F jsonFile=@"$NEW_FILE" https://HOSTED.FQDN/staking-ledgers/$HASH  -w "%{http_code}" -o /dev/null)
+    echo "Status code: $STATUS_CODE"
+    # Check if the upload was successful
+    if (( $STATUS_CODE == 200 )) ; then
+        echo "Successfully posted ledger...Archiving $NEW_FILE..."
+        mv "$NEW_FILE" "$YOUR_LEDGER_DIRECTORY/uploaded/$HASH.json"
+        echo "Archived $NEW_FILE"
+    elif (( $STATUS_CODE == 409 )) ; then
+        echo "Ledger already exists...Archiving $NEW_FILE..."
+        mv "$NEW_FILE" "$YOUR_LEDGER_DIRECTORY/uploaded/$HASH.json"
+        echo "Archived $NEW_FILE"
+    else
+        echo "UNKNOWN STATUS - Assuming failed to upload $NEW_FILE, status code: $STATUS_CODE"
+        echo leaving file $NEW_FILE in place
+    fi
+done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {

--- a/src/database/blockQueryFactory.ts
+++ b/src/database/blockQueryFactory.ts
@@ -283,7 +283,8 @@ ledger_hash as ledgerhash,
 to_char(to_timestamp("timestamp" / 1000) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') || '.' || 
     LPAD((("timestamp" % 1000)::text), 3, '0') || 'Z' as datetime
 FROM blocks
-WHERE id in (SELECT MAX(id) FROM blocks)`
+WHERE height in (SELECT MAX(height) FROM blocks)
+LIMIT 1`
 
 const getLastestBlockQueryv2 = `
 SELECT 
@@ -296,7 +297,8 @@ ledger_hash as ledgerhash,
 to_char(to_timestamp(cast ("timestamp" as bigint) / 1000) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS') || '.' || 
     LPAD(((cast("timestamp" as bigint) % 1000)::text), 3, '0') || 'Z' as datetime
 FROM blocks
-WHERE id in (SELECT MAX(id) FROM blocks);`
+WHERE height in (SELECT MAX(height) FROM blocks)
+LIMIT 1;`
 
 export const getLastestBlockQuery =
   configuration.blockDbVersion === 'v1' ?


### PR DESCRIPTION
getLastestBlockQuery (v1 and v2) were getting the max id from blocks -- but that id could reference a lower-height block.

Changed to check max height, not max id.

Id was deterministic; height is not. To retain this characteristic, the queries will just limit 1 to take any 1 block at the max height. 

Also added example uploader script for staking ledgers, and example deployment to alter the circuit breaker threshold.
