### PR TITLE
CVE 2023 42282

### DIFF
--- a/APIExamples.md
+++ b/APIExamples.md
@@ -1,6 +1,6 @@
 ## consensus
 
-[/consensus](https://api.minastakes.com)
+[/consensus](https://api.minastakes.com/consensus)
 
 The /consensus endpoint returns the current (ish) network tip
 

--- a/deploy/Dockerfile.linux
+++ b/deploy/Dockerfile.linux
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=21.6.1
+ARG NODE_VERSION=21.7.1
 
 FROM --platform=linux/amd64 node:${NODE_VERSION}-alpine
 WORKDIR /app

--- a/deploy/Dockerfile.mac
+++ b/deploy/Dockerfile.mac
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=21.6.1
+ARG NODE_VERSION=21.7.1
 
 FROM node:${NODE_VERSION}-alpine
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
package ip 2.0.0 has vulnerability CVE-2023-42282
upgrading node version to remediate

Changes docker files 

Also includes minor fix to example api docs.