### PR TITLE
Fixes issue with non-encrypted database connection

### DIFF
--- a/deploy/dev-deployment.yaml
+++ b/deploy/dev-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: **HOST FOR BLOCK DB QUERY**
         - name: BLOCK_DB_QUERY_PORT
           value: **PORT FOR BLOCK DB QUERY**
-        - name: BLOCK_DB_QUERY_DB_NAME
+        - name: BLOCK_DB_QUERY_NAME
           value: **MINA ARCHIVE DATABASE NAME**
         - name: BLOCK_DB_QUERY_PASSWORD
           valueFrom:

--- a/deploy/example-do-deployment.yaml
+++ b/deploy/example-do-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           value: **HOST FOR BLOCK DB QUERY**
         - name: BLOCK_DB_QUERY_PORT
           value: **PORT FOR BLOCK DB QUERY**
-        - name: BLOCK_DB_QUERY_DB_NAME
+        - name: BLOCK_DB_QUERY_NAME
           value: **MINA ARCHIVE DATABASE NAME**
         - name: BLOCK_DB_QUERY_PASSWORD
           valueFrom:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {

--- a/src/configurations/environmentConfiguration.ts
+++ b/src/configurations/environmentConfiguration.ts
@@ -14,7 +14,7 @@ function loadConfiguration(): Configuration {
     ledgerUploadApiUser: String(process.env.LEDGER_UPLOAD_API_USER),
     ledgerUploadApiPassword: String(process.env.LEDGER_UPLOAD_API_PASSWORD),
 
-    blockDbQueryConnectionSSL: Boolean(process.env.BLOCK_DB_QUERY_REQUIRE_SSL),
+    blockDbQueryConnectionSSL: process.env.BLOCK_DB_QUERY_REQUIRE_SSL === 'true',
     blockDbQueryCertificate: String(process.env.BLOCK_DB_QUERY_CERTIFICATE),
     blockDbQueryUser: String(process.env.BLOCK_DB_QUERY_USER),
     blockDbQueryPassword: String(process.env.BLOCK_DB_QUERY_PASSWORD),
@@ -23,7 +23,7 @@ function loadConfiguration(): Configuration {
     blockDbQueryName: String(process.env.BLOCK_DB_QUERY_NAME),
     blockDbVersion: String(process.env.BLOCK_DB_VERSION),
 
-    ledgerDbQueryConnectionSSL: Boolean(process.env.LEDGER_DB_QUERY_REQUIRE_SSL),
+    ledgerDbQueryConnectionSSL: process.env.LEDGER_DB_QUERY_REQUIRE_SSL === 'true',
     ledgerDbQueryCertificate: String(process.env.LEDGER_DB_QUERY_CERTIFICATE),
     ledgerDbQueryUser: String(process.env.LEDGER_DB_QUERY_USER),
     ledgerDbQueryPassword: String(process.env.LEDGER_DB_QUERY_PASSWORD),
@@ -31,7 +31,7 @@ function loadConfiguration(): Configuration {
     ledgerDbQueryPort: Number(process.env.LEDGER_DB_QUERY_PORT),
     ledgerDbQueryName: String(process.env.LEDGER_DB_QUERY_NAME),
 
-    ledgerDbCommandConnectionSSL: Boolean(process.env.LEDGER_DB_COMMAND_REQUIRE_SSL),
+    ledgerDbCommandConnectionSSL: process.env.LEDGER_DB_COMMAND_REQUIRE_SSL === 'true',
     ledgerDbCommandCertificate: String(process.env.LEDGER_DB_COMMAND_CERTIFICATE),
     ledgerDbCommandUser: String(process.env.LEDGER_DB_COMMAND_USER),
     ledgerDbCommandPassword: String(process.env.LEDGER_DB_COMMAND_PASSWORD),

--- a/src/controllers/stakingLedgersCommand.ts
+++ b/src/controllers/stakingLedgersCommand.ts
@@ -1,17 +1,17 @@
-import * as sldb from '../database/stakingLedgerDb';
-import * as db from '../database/blockArchiveDb';
+import { hashExists, updateEpoch, insertBatch } from '../database/stakingLedgerDb';
+import { getEpoch } from '../database/blockArchiveDb';
 import { ControllerResponse } from '../models/controller';
 import { LedgerEntry } from '../models/stakes';
 import { Logger } from 'pino';
 
 export async function uploadStakingLedger(log: Logger, ledgerJson: LedgerEntry[], hash: string, userSpecifiedEpoch: number | null) {
   log.info('uploadStakingLedger called for hash:', hash);
-  const [isAlreadyImported, hashEpoch] = await sldb.hashExists(hash, userSpecifiedEpoch);
+  const [isAlreadyImported, hashEpoch] = await hashExists(hash, userSpecifiedEpoch);
   if (isAlreadyImported) {
     if (hashEpoch === null) {
-      const epochToUpdate = await db.getEpoch(hash, userSpecifiedEpoch);
+      const epochToUpdate = await getEpoch(hash, userSpecifiedEpoch);
       if (epochToUpdate > 0) {
-        await sldb.updateEpoch(hash, epochToUpdate);
+        await updateEpoch(hash, epochToUpdate);
       }
     }
     log.info(`File with hash ${hash} for user specified epoch {userSpecifiedEpoch} was already imported`);
@@ -20,7 +20,7 @@ export async function uploadStakingLedger(log: Logger, ledgerJson: LedgerEntry[]
   }
   else {
     log.info(`Processing file ${hash}`);
-    await sldb.insertBatch(ledgerJson, hash, userSpecifiedEpoch);
+    await insertBatch(ledgerJson, hash, userSpecifiedEpoch);
     log.info(`Finished processing file ${hash}`);
     const controllerResponse: ControllerResponse = { responseMessages: [`Received file and processing for hash ${hash}`] };
     return (controllerResponse);

--- a/src/controllers/stakingLedgersQuery.ts
+++ b/src/controllers/stakingLedgersQuery.ts
@@ -1,4 +1,4 @@
-import * as sldb from '../database/stakingLedgerDb';
+import { getStakingLedgers, getStakingLedgersByEpoch } from '../database/stakingLedgerDb';
 import { Stake, LedgerEntry, Ledger } from '../models/stakes';
 import { MinaAddresses } from '../mina-addresses/minaAddressShareClass'
 import { ControllerResponse } from '../models/controller';
@@ -22,7 +22,7 @@ export async function getLedgerFromEpochForKey(key: string, epoch: number): Prom
 
 async function getStakes(ledgerHash: string, key: string): Promise<Ledger> {
   let totalStakingBalance = 0;
-  const ledger = await sldb.getStakingLedgers(ledgerHash, key);
+  const ledger = await getStakingLedgers(ledgerHash, key);
 
   const stakers: Stake[] = await Promise.all(
     ledger.map(async (stake: LedgerEntry) => {
@@ -44,7 +44,7 @@ async function getStakes(ledgerHash: string, key: string): Promise<Ledger> {
 
 async function getStakesByEpoch(key: string, epoch: number): Promise<Ledger> {
   let totalStakingBalance = 0;
-  const ledger = await sldb.getStakingLedgersByEpoch(key, epoch);
+  const ledger = await getStakingLedgersByEpoch(key, epoch);
 
   const stakers: Stake[] = await Promise.all(
     ledger.map(async (stake: LedgerEntry) => {

--- a/src/database/blockArchiveDb.ts
+++ b/src/database/blockArchiveDb.ts
@@ -4,7 +4,7 @@ import configuration from '../configurations/environmentConfiguration';
 import { getLastestBlockQuery, getMinMaxBlocksInSlotRangeQuery, getHeightMissingQuery, getNullParentsQuery, getEpochQuery, getBlocksQuery } from './blockQueryFactory';
 
 console.debug(`Creating query pool targeting ${configuration.blockDbQueryHost} at port ${configuration.blockDbQueryPort}`);
-const pool = createBlockQueryPool(configuration.blockDbQueryConnectionSSL);
+const pool = createBlockQueryPool();
 
 export async function getLatestBlock(): Promise<BlockSummary> {
   const result = await pool.query(getLastestBlockQuery);

--- a/src/database/blockQueryFactory.ts
+++ b/src/database/blockQueryFactory.ts
@@ -362,13 +362,26 @@ export const getMinMaxBlocksInSlotRangeQuery = (fork: number): string => {
   return query;
 }
 
-export const getEpochQuery = `
+const getEpochQueryv1 = `
+SELECT MIN(b.global_slot_since_genesis), MAX(b.global_slot_since_genesis)
+FROM blocks b
+INNER JOIN epoch_data ed ON b.staking_epoch_data_id = ed.id
+INNER JOIN snarked_ledger_hashes slh ON ed.ledger_hash_id = slh.id
+WHERE slh.value = $1
+`;
+
+const getEpochQueryv2 = `
 SELECT MIN(b.global_slot_since_hard_fork), MAX(b.global_slot_since_hard_fork)
 FROM blocks b
 INNER JOIN epoch_data ed ON b.staking_epoch_data_id = ed.id
 INNER JOIN snarked_ledger_hashes slh ON ed.ledger_hash_id = slh.id
 WHERE slh.value = $1
 `;
+export const getEpochQuery =
+  configuration.blockDbVersion === 'v1' ?
+    getEpochQueryv1
+    : getEpochQueryv2;
+
 
 export const getHeightMissingQuery = `
 SELECT h as height

--- a/src/database/databaseFactory.ts
+++ b/src/database/databaseFactory.ts
@@ -1,75 +1,68 @@
-import { Pool } from 'pg';
+import { Pool, PoolConfig } from 'pg';
 import configuration from '../configurations/environmentConfiguration';
 
-export function createBlockQueryPool(useSSL: boolean) {
-  if (useSSL) {
-
-    return new Pool({
-      user: configuration.blockDbQueryUser,
-      host: configuration.blockDbQueryHost,
-      database: configuration.blockDbQueryName,
-      password: configuration.blockDbQueryPassword,
-      port: configuration.blockDbQueryPort,
-      ssl: {
-        ca: configuration.blockDbQueryCertificate,
-        rejectUnauthorized: false,
-      },
-    });
-  }
-
-  return new Pool({
-    user: configuration.blockDbQueryUser,
-    host: configuration.blockDbQueryHost,
-    database: configuration.blockDbQueryName,
-    password: configuration.blockDbQueryPassword,
-    port: configuration.blockDbQueryPort,
-  });
+interface PGConfig extends PoolConfig {
+  ssl?: {
+    ca: string;
+    rejectUnauthorized: boolean;
+  };
 }
 
-export function createLedgerQueryPool(useSSL: boolean) {
-  if (useSSL) {
-    return new Pool({
-      user: configuration.ledgerDbQueryUser,
-      host: configuration.ledgerDbQueryHost,
-      database: configuration.ledgerDbQueryName,
-      password: configuration.ledgerDbQueryPassword,
-      port: configuration.ledgerDbQueryPort,
-      ssl: {
-        ca: configuration.ledgerDbQueryCertificate,
-        rejectUnauthorized: false,
-      },
-    });
-  }
-
-  return new Pool({
-    user: configuration.ledgerDbQueryUser,
-    host: configuration.ledgerDbQueryHost,
-    database: configuration.ledgerDbQueryName,
-    password: configuration.ledgerDbQueryPassword,
-    port: configuration.ledgerDbQueryPort,
-  });
+function createConfig(user: string, host: string, database: string, password: string, port: number, certificate: string, useSSL: boolean): PGConfig {
+  return useSSL ? {
+    user,
+    host,
+    database,
+    password,
+    port,
+    ssl: {
+      ca: certificate,
+      rejectUnauthorized: false,
+    },
+  } : {
+    user,
+    host,
+    database,
+    password,
+    port,
+  };
 }
 
-export function createStakingLedgerCommandPool(useSSL: boolean) {
-  if (useSSL) {
-    return new Pool({
-      user: configuration.ledgerDbCommandUser,
-      host: configuration.ledgerDbCommandHost,
-      database: configuration.ledgerDbCommandName,
-      password: configuration.ledgerDbCommandPassword,
-      port: configuration.ledgerDbCommandPort,
-      ssl: {
-        ca: configuration.ledgerDbCommandCertificate,
-        rejectUnauthorized: false,
-      },
-    });
-  }
+export function createBlockQueryPool() {
+  const config = createConfig(
+    configuration.blockDbQueryUser,
+    configuration.blockDbQueryHost,
+    configuration.blockDbQueryName,
+    configuration.blockDbQueryPassword,
+    configuration.blockDbQueryPort,
+    configuration.blockDbQueryCertificate,
+    configuration.blockDbQueryConnectionSSL,
+  );
+  return new Pool(config);
+}
 
-  return new Pool({
-    user: configuration.ledgerDbCommandUser,
-    host: configuration.ledgerDbCommandHost,
-    database: configuration.ledgerDbCommandName,
-    password: configuration.ledgerDbCommandPassword,
-    port: configuration.ledgerDbCommandPort,
-  });
+export function createLedgerQueryPool() {
+  const config = createConfig(
+    configuration.ledgerDbQueryUser,
+    configuration.ledgerDbQueryHost,
+    configuration.ledgerDbQueryName,
+    configuration.ledgerDbQueryPassword,
+    configuration.ledgerDbQueryPort,
+    configuration.ledgerDbQueryCertificate,
+    configuration.ledgerDbQueryConnectionSSL,
+  );
+  return new Pool(config);
+}
+
+export function createStakingLedgerCommandPool() {
+  const config = createConfig(
+    configuration.ledgerDbCommandUser,
+    configuration.ledgerDbCommandHost,
+    configuration.ledgerDbCommandName,
+    configuration.ledgerDbCommandPassword,
+    configuration.ledgerDbCommandPort,
+    configuration.ledgerDbCommandCertificate,
+    configuration.ledgerDbCommandConnectionSSL,
+  );
+  return new Pool(config);
 }

--- a/src/database/stakingLedgerDb.ts
+++ b/src/database/stakingLedgerDb.ts
@@ -1,13 +1,13 @@
 import configuration from '../configurations/environmentConfiguration';
 import { LedgerEntry, TimedStakingLedgerResultRow } from '../models/stakes';
-import * as db from './blockArchiveDb';
+import { getEpoch } from './blockArchiveDb';
 import { createLedgerQueryPool, createStakingLedgerCommandPool } from './databaseFactory'
 
 console.debug(`Creating query pool targeting ${configuration.ledgerDbQueryHost} at port ${configuration.ledgerDbQueryPort}`);
-const sldb = createLedgerQueryPool(configuration.ledgerDbQueryConnectionSSL);
+const sldb = createLedgerQueryPool();
 
 console.debug(`Creating command pool targeting ${configuration.ledgerDbCommandHost} at port ${configuration.ledgerDbCommandPort}`);
-const commanddb = createStakingLedgerCommandPool(configuration.ledgerDbCommandConnectionSSL);
+const commanddb = createStakingLedgerCommandPool();
 
 export async function getStakingLedgers(hash: string, key: string) {
   const query = `SELECT 
@@ -65,7 +65,7 @@ export async function hashExists(hash: string, userSpecifiedEpoch: number | null
 export async function insertBatch(dataArray: LedgerEntry[], hash: string, userSpecifiedEpoch: number | null): Promise<void> {
   console.debug(`insertBatch called: ${dataArray.length} records to insert.`);
   let epoch = -1;
-  epoch = await db.getEpoch(hash, userSpecifiedEpoch);
+  epoch = await getEpoch(hash, userSpecifiedEpoch);
   const client = await commanddb.connect();
   try {
     await client.query('BEGIN');

--- a/src/routes/stakingLedgers.ts
+++ b/src/routes/stakingLedgers.ts
@@ -1,3 +1,4 @@
+// Handles /staking-ledgers endpoint
 import express from 'express';
 import multer from 'multer';
 import basicAuth from 'express-basic-auth';
@@ -55,6 +56,9 @@ router.post('/:ledgerHash', auth, upload.single('jsonFile'), async (req, res) =>
 
 router.get('/:ledgerHash', async (req, res) => {
   const key = req.query.key as string;
+  if (!key) {
+    return res.status(400).send('No key provided');
+  }
   const ledgerHash = req.params.ledgerHash as string;
   try {
     const controllerResponse: ControllerResponse = await getLedgerFromHashForKey(ledgerHash, key);
@@ -77,6 +81,9 @@ router.get('/:ledgerHash', async (req, res) => {
 router.get('/epoch/:epoch', async (req, res) => {
   const key = req.query.key as string;
   const epoch = parseInt(req.params.epoch);
+  if (!key) {
+    return res.status(400).send('No key provided');
+  }
   try {
     const controllerResponse: ControllerResponse = await getLedgerFromEpochForKey(key, epoch);
     const responseData: Ledger = controllerResponse.responseData as Ledger;


### PR DESCRIPTION
Was improperly evaluating config value of false as true, so always thought database connections were to use SSL. Fixed by changing environmentConfiguration loader. 

Verified no other boolean values handled incorrectly. 

Also found bug in epoch query (needs a version factory to handle global_slot_since_genesis vs. _since_hard_fork).

Minor cleanup - don't import * from database providers, be explicit.

Don't pass some config value as param when most are read straight from config - simplified interface to db factory.

Refactored databaseFactory.ts to simplify some redundancy.

Added guard on staking-ledgers route to return 400 if no key provided when querying. (It was just returning empty results which can be confusing.)