### PR TITLE
Improve circuit breaker to detect missing parents  Fixes #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {

--- a/src/database/blockArchiveDb.ts
+++ b/src/database/blockArchiveDb.ts
@@ -19,13 +19,13 @@ export async function getMinMaxBlocksInSlotRange(min: number, max: number, fork:
   return [epochminblockheight, epochmaxblockheight];
 }
 
-async function getHeightMissing(minHeight: number, maxHeight: number): Promise<number[]> {
+export async function getHeightMissing(minHeight: number, maxHeight: number): Promise<number[]> {
   const result = await pool.query(getHeightMissingQuery, [minHeight, maxHeight]);
   const heights: Height[] = result.rows;
   return heights.map((x) => x.height);
 }
 
-async function getNullParents(minHeight: number, maxHeight: number): Promise<number[]> {
+export async function getNullParents(minHeight: number, maxHeight: number): Promise<number[]> {
   const result = await pool.query(getNullParentsQuery, [minHeight, maxHeight]);
   const heights: Height[] = result.rows;
   return heights.map((x) => x.height);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ app.use(helmet());
 app.use(limiter);
 app.use(expressLogger);
 
-app.use('/consensus', cors(), consensusRouter);
+app.use('/consensus', cors(), checkTrustArchiveDatabaseHeight, consensusRouter);
 app.use('/epoch', cors(), checkTrustArchiveDatabaseHeight, epochRouter);
 app.use('/blocks', cors(), checkTrustArchiveDatabaseHeight, blocksRouter);
 app.use('/staking-ledgers', cors(), stakingLedgerRouter);

--- a/src/jobs/archiveDbRecencyChecker.ts
+++ b/src/jobs/archiveDbRecencyChecker.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, InMemoryCache, HttpLink, gql } from '@apollo/client/core';
 import cron from 'node-cron';
 import configuration from '../configurations/environmentConfiguration';
-import * as db from '../database/blockArchiveDb';
+import { getLatestBlock, getHeightMissing, getNullParents } from '../database/blockArchiveDb';
 import { BlockSummary } from '../models/blocks';
 import { logger } from '../index';
 
@@ -33,12 +33,13 @@ async function getBlockHeightFromNode(node: string): Promise<number> {
 
 // Create a function that gets the current block height from the /consensus endpoint
 async function getCurrentBlockHeight(): Promise<number> {
-  const blockSummary: BlockSummary = await db.getLatestBlock();
+  const blockSummary: BlockSummary = await getLatestBlock();
   return blockSummary.blockheight;
 }
 
 // Create a function that compares the block heights and updates the database if necessary
-async function compareBlockHeights() {
+async function compareBlockHeights(): Promise<boolean> {
+  let trustArchive = true;
   let blockHeightFromNode = 0;
   for (const checkNode of configuration.checkNodes) {
     try {
@@ -54,21 +55,74 @@ async function compareBlockHeights() {
     }
   }
   if (blockHeightFromNode == 0) {
-    logger.error('Failed to get higher block height from all nodes');
-    return;
+    logger.error('Failed to get block height from all nodes');
+    trustArchive = false;
+    return trustArchive;
   }
   const blockHeightFromArchiveDb = await getCurrentBlockHeight();
   // If the block height from the node is greater than the block height from the archive db by more than env configured threshold blocks
   // then you cannot trust the archive db height updating the configuration value trustArchiveDatabaseHeight to false will cause all apis to start returning errors.
   if (blockHeightFromNode - configuration.archiveDbRecencyThreshold >= blockHeightFromArchiveDb) {
-    configuration.trustArchiveDatabaseHeight = false;
-  } else { configuration.trustArchiveDatabaseHeight = true; }
-  logger.info(`Finished archive db trust check. Current archive db block height: ${blockHeightFromArchiveDb}, block height from node: ${blockHeightFromNode}, trustArchiveDatabaseHeight: ${configuration.trustArchiveDatabaseHeight}`);
+    trustArchive = false;
+    logger.warn(`Current archive db block height: ${blockHeightFromArchiveDb}, block height from node(s): ${blockHeightFromNode}`);
+  } else {
+    trustArchive = true;
+    logger.info(`Current archive db block height: ${blockHeightFromArchiveDb}, block height from node(s): ${blockHeightFromNode}`);
+  }
+  return trustArchive;
+}
+
+async function checkMissingHeightsLast5000Blocks(): Promise<boolean> {
+  let trustArchive = true
+  const blockHeightFromArchiveDb = await getCurrentBlockHeight();
+  const lowerBoundary = blockHeightFromArchiveDb - 5000 > 0 ? blockHeightFromArchiveDb - 5000 : 0;
+  const missingHeights = await getHeightMissing(lowerBoundary, blockHeightFromArchiveDb);
+  if (missingHeights.length > 0) {
+    logger.warn(`Archive database is missing blocks since height ${lowerBoundary}. Missing blocks: ${JSON.stringify(missingHeights)}`);
+    trustArchive = false;
+  } else {
+    logger.info(`Archive database has all blocks since height ${lowerBoundary}`);
+    trustArchive = true;
+  }
+  return trustArchive;
+}
+
+async function checkNullParentsLast5000Blocks(): Promise<boolean> {
+  let trustArchive = true
+  const blockHeightFromArchiveDb = await getCurrentBlockHeight();
+  const lowerBoundary = blockHeightFromArchiveDb - 5000 > 0 ? blockHeightFromArchiveDb - 5000 : 0;
+  const nullParents = await getNullParents(lowerBoundary, blockHeightFromArchiveDb);
+  if (nullParents.length > 0) {
+    logger.warn(`Archive database has null parents. The following blocks are missing parent: ${JSON.stringify(nullParents)}`);
+    trustArchive = false;
+  } else {
+    logger.info(`Archive database has parents for all blocks since ${lowerBoundary}`);
+    trustArchive = true;
+  }
+  return trustArchive;
+}
+
+async function validateArchiveDb() {
+  try {
+    const dbInSyncWithNodes = await compareBlockHeights();
+    const noMissingBlocks = await checkMissingHeightsLast5000Blocks();
+    const noNullParents = await checkNullParentsLast5000Blocks();
+    logger.info(`Archive db validation results: dbInSyncWithNodes: ${dbInSyncWithNodes}, noMissingBlocks: ${noMissingBlocks}, noNullParents: ${noNullParents}`);
+    if (dbInSyncWithNodes && noMissingBlocks && noNullParents) {
+      logger.info('Archive db is trusted. All checks passed.');
+      configuration.trustArchiveDatabaseHeight = true;
+    } else {
+      logger.error('Archive db is NOT trusted. One or more checks failed.');
+      configuration.trustArchiveDatabaseHeight = false;
+    }
+  } catch (error) {
+    logger.error(`Failed to validate archive db: ${error}`);
+  }
 }
 
 export default function startBackgroundTask() {
   // Schedule every N minutes to check the archive db height vs. node heights based on env configuration
   const schedule = `*/${configuration.archiveDbCheckInterval} * * * *`
-  logger.info(`Scheduling background task to check archive db height vs. node heights every ${schedule}`);
-  cron.schedule(schedule, compareBlockHeights);
+  logger.info(`Scheduling background task to check archive db height vs. node heights, and look for gaps in consensus chain every ${schedule}`);
+  cron.schedule(schedule, validateArchiveDb);
 }


### PR DESCRIPTION
Circuit breaker now also trips if:

- in the last 5,000 blocks, any block height is missing
- in the last 5,000 blocks, any block is missing a parent

Circuit breaker now also affects /consensus endpoint and it will 503 as well if the breaker trips.