### PR TITLE
Jrwashburn/issue29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {

--- a/src/routes/epoch.ts
+++ b/src/routes/epoch.ts
@@ -19,6 +19,10 @@ router.get('/:epoch/', async (req, res) => {
     messages.push({ warning: 'Fork was not provided, defaulted to 0' });
   }
 
+  if (fork > 0 && configuration.blockDbVersion == 'v1') {
+    return res.status(400).send('Invalid fork for this archive database version');
+  }
+
   try {
     const [minSlot, maxSlot] = getMinMaxSlotHeight(epoch);
     const [epochMinBlockHeight, epochMaxBlockHeight] = await db.getMinMaxBlocksInSlotRange(minSlot, maxSlot, fork);


### PR DESCRIPTION
Return HTTP 400 if requesting fork 1 from a pre-migrated (v1) archive database. This is handled at the /epoch router and rejected up-front before it can throw db errors.

Improve query consistency for varioius scenarios.

Add support for fork 0 query on v2 database to get epoch data.