### PR TITLE
Snyk vuln 20240410

### DIFF
--- a/deploy/Dockerfile.linux
+++ b/deploy/Dockerfile.linux
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=21.7.1
+ARG NODE_VERSION=21.7.2
 
 FROM --platform=linux/amd64 node:${NODE_VERSION}-alpine
 WORKDIR /app

--- a/deploy/Dockerfile.mac
+++ b/deploy/Dockerfile.mac
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=21.7.1
+ARG NODE_VERSION=21.7.2
 
 FROM node:${NODE_VERSION}-alpine
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Snyk reprorted vulnerabilities:
Allocation of Resources Without Limits or Throttling (upgrade image tag from node:21.7.1-alpine to node 21.7.2)
HTTP Request Smuggling (upgrade image tag from node:21.7.1-alpine to node 21.7.2)
Open Redirect (already fixed pinning express 4.19.2, but still reporting - verify after this merge.) 

