### PR TITLE
Use decimal.js to handle floating point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payouts-data-provider",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Data provider API for mina-pool-payouts",
   "main": "index.js",
   "scripts": {
@@ -16,6 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.9.6",
     "cors": "^2.8.5",
+    "decimal.js": "^10.4.3",
     "dotenv": "^16.4.1",
     "express": "4.19.2",
     "express-basic-auth": "^1.2.1",

--- a/src/database/stakingLedgerDb.ts
+++ b/src/database/stakingLedgerDb.ts
@@ -20,7 +20,8 @@ export async function getStakingLedgers(hash: string, key: string) {
 		timing_vesting_period, 
 		timing_vesting_increment 
 		FROM public.staking_ledger
-		WHERE hash = $1 AND delegate_key = $2`;
+		WHERE hash = $1 AND delegate_key = $2
+    ORDER BY public_key ASC`;
   const result = await sldb.query(query, [hash, key]);
   return buildLedgerEntries(result.rows);
 }
@@ -36,7 +37,8 @@ export async function getStakingLedgersByEpoch(key: string, epoch: number) {
 		timing_vesting_period, 
 		timing_vesting_increment 
 		FROM public.staking_ledger
-		WHERE delegate_key = $1 AND epoch = $2`;
+		WHERE delegate_key = $1 AND epoch = $2
+    ORDER BY public_key ASC`;
   const result = await sldb.query(query, [key, epoch.toString()]);
   return buildLedgerEntries(result.rows);
 }

--- a/src/database/stakingLedgerDb.ts
+++ b/src/database/stakingLedgerDb.ts
@@ -20,8 +20,7 @@ export async function getStakingLedgers(hash: string, key: string) {
 		timing_vesting_period, 
 		timing_vesting_increment 
 		FROM public.staking_ledger
-		WHERE hash = $1 AND delegate_key = $2
-    ORDER BY public_key ASC`;
+		WHERE hash = $1 AND delegate_key = $2`;
   const result = await sldb.query(query, [hash, key]);
   return buildLedgerEntries(result.rows);
 }
@@ -37,8 +36,7 @@ export async function getStakingLedgersByEpoch(key: string, epoch: number) {
 		timing_vesting_period, 
 		timing_vesting_increment 
 		FROM public.staking_ledger
-		WHERE delegate_key = $1 AND epoch = $2
-    ORDER BY public_key ASC`;
+		WHERE delegate_key = $1 AND epoch = $2`;
   const result = await sldb.query(query, [key, epoch.toString()]);
   return buildLedgerEntries(result.rows);
 }


### PR DESCRIPTION
Unsorted staking ledger results may sometimes have different total staking amounts because of floating point math.

Changed to use decimal.js to add staking balances, etc. 