### PR TITLE
Jrwashburn/issue55

### DIFF
--- a/src/database/blockQueryFactory.ts
+++ b/src/database/blockQueryFactory.ts
@@ -7,11 +7,13 @@ import configuration from '../configurations/environmentConfiguration';
 // blocks.timestamp is now text 
 // snarked ledger hash.value is now text
 
+export const getPoolCreatorIdQuery = `SELECT id FROM public_keys where value = $1`;
+
 const getBlocksQueryv1 = `
 WITH block_range AS (
   SELECT min(id) AS min_id, max(id) AS max_id
   FROM blocks
-  WHERE height >= $2 and height <= $3
+  WHERE height >= $2 AND height <= $3 AND creator_id = $4
 )
 SELECT
   b.id AS id,
@@ -132,6 +134,7 @@ WHERE
 AND pkc.value = $1
 AND b.height >= $2
 AND b.height <= $3
+AND b.creator_id = $4
 ORDER BY b.height DESC
 `;
 
@@ -139,7 +142,7 @@ const getBlocksQueryv2 = `
 WITH block_range AS (
   SELECT min(id) AS min_id, max(id) AS max_id
   FROM blocks
-  WHERE height >= $2 and height <= $3
+  WHERE height >= $2 AND height <= $3 AND creator_id = $4
 )
 SELECT
   b.id AS id,
@@ -260,6 +263,7 @@ WHERE
 AND pkc.value = $1
 AND b.height >= $2
 AND b.height <= $3
+AND b.creator_id = $4
 ORDER BY b.height DESC
 `;
 

--- a/src/database/stakingLedgerDb.ts
+++ b/src/database/stakingLedgerDb.ts
@@ -70,7 +70,7 @@ export async function insertBatch(dataArray: StakingLedgerSourceRow[], hash: str
   try {
     await client.query('BEGIN');
     const batchSize = 1000;
-    console.log('Number of records:', dataArray.length);
+    console.debug('Number of records:', dataArray.length);
     for (let i = 0; i < dataArray.length; i += batchSize) {
       const batch = dataArray.slice(i, i + batchSize);
       console.debug(`Processing batch ${i} to ${i + batchSize}`);


### PR DESCRIPTION
Get Blocks query may timeout for some users with larger pools.

Changed process to get id of block creator first, then pass that into the getBlocks query to optimize the query plan. Cut query execution time from 100s to 2-4s with example pool.